### PR TITLE
Restyle marketing site with light theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About NeuraTask | Built for SMEs by operators and engineers</title>
+    <meta
+      name="description"
+      content="Meet NeuraTask, the AI-powered ERP built by operators and engineers for small and midsize teams that need practical, reliable tools."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Built for SMEs by operators and engineers.</h1>
+            <p class="lead">We’ve shipped for scrappy teams ourselves. NeuraTask is the tool we wanted—fast to adopt, hard to outgrow.</p>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="NeuraTask team illustration.">
+              Team illustration placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="values">
+        <h2>Values</h2>
+        <ul class="list">
+          <li>Practical</li>
+          <li>Reliable</li>
+          <li>Transparent</li>
+          <li>Customer-obsessed</li>
+        </ul>
+      </section>
+
+      <section class="section" id="cta">
+        <div class="final-cta">
+          <h2>Meet the team</h2>
+          <p>We’d love to show you what we’re building.</p>
+          <div class="button-group">
+            <a class="button button-primary" href="contact.html">Book a demo</a>
+            <a class="button button-secondary" href="contact.html">Contact us</a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,698 @@
+:root {
+  --color-background: #f8fafc;
+  --color-surface: #ffffff;
+  --color-muted: #e2e8f0;
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-accent: #38bdf8;
+  --color-accent-strong: #2563eb;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --font-body: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --max-width: 1200px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 25px 50px rgba(15, 23, 42, 0.08);
+  --shadow-medium: 0 12px 30px rgba(15, 23, 42, 0.12);
+  --gradient-hero: radial-gradient(circle at top right, rgba(56, 189, 248, 0.22), transparent 60%),
+    radial-gradient(circle at bottom left, rgba(37, 99, 235, 0.18), transparent 55%),
+    linear-gradient(145deg, #f8fafc, #ffffff);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+header {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+}
+
+.navbar {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.nav-logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.nav-links a.active {
+  color: var(--color-text);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button-primary {
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
+  color: #ffffff;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.25);
+}
+
+.button-secondary {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-accent-strong);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(37, 99, 235, 0.22);
+}
+
+main {
+  padding: 0 1.5rem 6rem;
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 4rem 0;
+}
+
+.section h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.section p.lead {
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  max-width: 700px;
+}
+
+.hero {
+  padding-top: 6rem;
+  background: var(--gradient-hero);
+  border-radius: var(--radius-lg);
+  margin-top: 2rem;
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero-content h1 {
+  font-size: 3rem;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero-content p {
+  font-size: 1.15rem;
+  color: var(--color-text-muted);
+  margin-bottom: 2rem;
+}
+
+.hero-proof {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+}
+
+.hero-image {
+  position: relative;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-medium);
+}
+
+.mockup-window {
+  border-radius: 14px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.mockup-window .kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.kpi-card {
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: #f1f5f9;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.chat-bubble {
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(56, 189, 248, 0.15));
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  box-shadow: 0 0 30px rgba(56, 189, 248, 0.25);
+}
+
+.trust-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 1.75rem;
+  margin-top: 3rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.logo-pill {
+  padding: 0.8rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--color-text-muted);
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-accent-strong);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.tile {
+  background: var(--color-surface);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.5rem;
+}
+
+.metric-card {
+  border-radius: var(--radius-md);
+  padding: 1.2rem;
+  border: 1px solid var(--color-border);
+  background: #ffffff;
+  box-shadow: var(--shadow-soft);
+}
+
+.metric-card h3 {
+  font-size: 2rem;
+  margin: 0;
+  color: var(--color-accent-strong);
+}
+
+.stepper {
+  display: grid;
+  gap: 1.5rem;
+  counter-reset: step;
+}
+
+.step {
+  position: relative;
+  padding-left: 3rem;
+  border-left: 1px solid var(--color-border);
+}
+
+.step::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: -1.5rem;
+  top: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: var(--color-accent-strong);
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.25);
+}
+
+.quote {
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+  border-left: 3px solid var(--color-accent);
+  padding-left: 1.2rem;
+}
+
+.quote cite {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.final-cta {
+  text-align: center;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.12));
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: var(--radius-lg);
+  padding: 3rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.final-cta h2 {
+  font-size: 2.3rem;
+  margin: 0;
+}
+
+.final-cta p {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.final-cta .button-group {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+footer {
+  border-top: 1px solid var(--color-border);
+  background: #ffffff;
+  padding: 4rem 1.5rem;
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 2rem;
+}
+
+.footer-col h4 {
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.footer-col ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.footer-col a {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.social-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.newsletter {
+  background: var(--color-surface);
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.newsletter form {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.newsletter input[type="email"] {
+  flex: 1;
+  min-width: 220px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #f1f5f9;
+  color: var(--color-text);
+}
+
+.tagline {
+  color: var(--color-text-muted);
+  max-width: 420px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1.5rem;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--color-border);
+  padding: 1rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.faq {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.faq-item h3 {
+  margin: 0 0 0.5rem;
+}
+
+.integration-roadmap {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.integration-roadmap span {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-accent-strong);
+  font-size: 0.9rem;
+}
+
+.contact-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.contact-form label {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.contact-form input,
+.contact-form textarea,
+.contact-form select {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #f8fafc;
+  color: var(--color-text);
+}
+
+.contact-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.contact-sidebar {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(15, 23, 42, 0.05));
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.badge-grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.badge-grid span {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  font-size: 0.85rem;
+  color: var(--color-accent-strong);
+}
+
+blockquote {
+  margin: 0;
+}
+
+.table caption {
+  caption-side: top;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.hero-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.1), rgba(37, 99, 235, 0.05));
+}
+
+.placeholder-img {
+  width: 100%;
+  aspect-ratio: 16/10;
+  border-radius: var(--radius-md);
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(148, 163, 184, 0.15),
+      rgba(148, 163, 184, 0.15) 12px,
+      rgba(37, 99, 235, 0.12) 12px,
+      rgba(37, 99, 235, 0.12) 24px
+    );
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  display: grid;
+  place-items: center;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.highlight {
+  color: var(--color-accent);
+}
+
+.layout-split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.list li::before {
+  content: "";
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  margin-right: 0.6rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+}
+
+@media (max-width: 960px) {
+  .nav-links {
+    display: none;
+  }
+
+  .nav-links.open {
+    display: grid;
+    position: absolute;
+    top: 100%;
+    right: 1.5rem;
+    background: #ffffff;
+    border: 1px solid var(--color-border);
+    padding: 1.5rem;
+    border-radius: var(--radius-md);
+    gap: 1rem;
+    box-shadow: var(--shadow-medium);
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    align-items: center;
+    justify-content: center;
+    background: #ffffff;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+
+  .nav-actions {
+    display: none;
+  }
+
+  main {
+    padding: 0 1.25rem 4rem;
+  }
+
+  .hero-content h1 {
+    font-size: 2.3rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-content p {
+    font-size: 1.05rem;
+  }
+
+  .section {
+    padding: 3rem 0;
+  }
+
+  .hero {
+    padding-top: 4rem;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,22 @@
+const navToggle = document.querySelector('[data-nav-toggle]');
+const navLinks = document.querySelector('.nav-links');
+
+if (navToggle && navLinks) {
+  navToggle.addEventListener('click', () => {
+    navLinks.classList.toggle('open');
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+  });
+}
+
+const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+
+if (navLinks) {
+  const anchors = navLinks.querySelectorAll('a');
+  anchors.forEach((anchor) => {
+    const href = anchor.getAttribute('href');
+    if (href === currentPath || (currentPath === 'index.html' && href === './')) {
+      anchor.classList.add('active');
+    }
+  });
+}

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact NeuraTask | Let’s solve your ops bottlenecks</title>
+    <meta
+      name="description"
+      content="Contact NeuraTask to book a demo, ask questions, or connect with our team about your SME operations."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Let’s solve your ops bottlenecks.</h1>
+            <p class="lead">Tell us about your team and workflows. We’ll tailor a walkthrough or set you up with a free trial.</p>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Calendly demo embed placeholder.">
+              Demo scheduling placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="contact">
+        <div class="contact-layout">
+          <form class="contact-form">
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" required />
+
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" required />
+
+            <label for="company">Company</label>
+            <input id="company" name="company" type="text" required />
+
+            <label for="team-size">Team size</label>
+            <select id="team-size" name="team-size">
+              <option value="1-10">1-10</option>
+              <option value="11-25">11-25</option>
+              <option value="26-50">26-50</option>
+              <option value="51-100">51-100</option>
+              <option value="100+">100+</option>
+            </select>
+
+            <label for="phone">Phone <span style="color: var(--color-text-muted);">(optional)</span></label>
+            <input id="phone" name="phone" type="tel" />
+
+            <label for="message">Message</label>
+            <textarea id="message" name="message" placeholder="Share your goals, current tools, or go-live timeline."></textarea>
+
+            <button class="button button-primary" type="submit">Submit</button>
+          </form>
+          <aside class="contact-sidebar">
+            <h2>Book a live demo</h2>
+            <p>Pick a time that works and see NeuraTask with your data.</p>
+            <div class="placeholder-img" role="img" aria-label="Calendly embed placeholder.">
+              Calendly embed placeholder
+            </div>
+            <p>Prefer email? <a href="mailto:hello@neuratask.com">hello@neuratask.com</a></p>
+          </aside>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/features.html
+++ b/features.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Features | AI Copilot, Document AI, Inventory &amp; Time</title>
+    <meta
+      name="description"
+      content="Dive into NeuraTask features including AI Copilot, Document AI, tasks & messaging, inventory, parts to order, and time tracking."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero" id="copilot">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <span class="badge">AI Copilot</span>
+            <h1>Copilot handles the busywork.</h1>
+            <p class="lead">
+              Ask in plain language. Copilot creates quotes, POs, tasks; fills forms from scans; updates statuses; and summarizes threads. Everything is permission-aware and auditable.
+            </p>
+            <ul class="list">
+              <li>Natural-language commands</li>
+              <li>Action confirmations</li>
+              <li>Draft-then-approve mode</li>
+              <li>Full audit trail</li>
+            </ul>
+            <div class="button-group">
+              <a class="button button-primary" href="contact.html">Book a demo</a>
+              <a class="button button-secondary" href="pricing.html">Start free trial</a>
+            </div>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Approve Copilot actions before execution.">
+              Copilot approval UI placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="document-ai">
+        <div class="grid-2">
+          <div>
+            <h2>Scan, extract, auto-fill.</h2>
+            <p>
+              Snap a photo or upload a PDF. NeuraTask reads it, fills the right fields, and links it to the correct order.
+            </p>
+            <ul class="list">
+              <li>Delivery notes</li>
+              <li>Supplier invoices</li>
+              <li>Packing slips</li>
+              <li>Timesheets</li>
+            </ul>
+          </div>
+          <div class="placeholder-img" role="img" aria-label="Document AI extracting data from paperwork.">
+            Document AI illustration placeholder
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="tasks">
+        <div class="grid-2">
+          <div class="placeholder-img" role="img" aria-label="Contextual tasks and messaging view.">
+            Tasks and messaging placeholder
+          </div>
+          <div>
+            <h2>Work routes itself.</h2>
+            <p>Assign tasks from any record. See who’s on it, due dates, blockers. Message in context.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="inventory">
+        <div class="grid-2">
+          <div>
+            <h2>Buy the right parts at the right time.</h2>
+            <p>Real-time stock, reorder alerts, lead times, and an aggregated parts-to-order queue.</p>
+          </div>
+          <div class="placeholder-img" role="img" aria-label="Inventory levels and parts to order queue.">
+            Inventory management placeholder
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="time">
+        <div class="grid-2">
+          <div class="placeholder-img" role="img" aria-label="Mobile time tracking interface.">
+            Time tracking UI placeholder
+          </div>
+          <div>
+            <h2>Time that powers your P&amp;L.</h2>
+            <p>Simple clock-in/out on mobile, project time on jobs, and roll-up labor costs.</p>
+          </div>
+        </div>
+        <a class="button button-primary" href="pricing.html">Start free trial</a>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask | AI-Powered ERP for SMEs — Inventory, Sales, Purchasing, Time &amp; Finance</title>
+    <meta
+      name="description"
+      content="Run your SME on one AI-powered platform. NeuraTask’s Copilot chats, fills forms, routes tasks, and syncs inventory, sales, purchasing, time, and finance. Web, desktop, and mobile."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero" id="hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Run your entire SME on one AI-powered platform.</h1>
+            <p>
+              NeuraTask is the ERP with an AI Copilot that chats, fills forms, routes tasks, and keeps inventory, sales, purchasing, time, and finance in sync—across web, desktop, and mobile.
+            </p>
+            <div class="button-group">
+              <a class="button button-primary" href="contact.html">Book a demo</a>
+              <a class="button button-secondary" href="pricing.html">Start free trial</a>
+            </div>
+            <div class="hero-proof"><strong>Early users report 35% faster quote-to-cash and 50% fewer stockouts.*</strong></div>
+          </div>
+          <div class="hero-image">
+            <div class="mockup-window" aria-hidden="false">
+              <div class="chat-bubble" role="img" aria-label="NeuraTask dashboard with AI Copilot creating a purchase order from chat.">
+                Copilot: “Create a PO for parts on Sales Order #1043 and assign to Vendor A.”
+              </div>
+              <div class="kpi-grid">
+                <div class="kpi-card">
+                  <p>Inventory accuracy</p>
+                  <h3>99.5%</h3>
+                </div>
+                <div class="kpi-card">
+                  <p>Open POs</p>
+                  <h3>12</h3>
+                </div>
+                <div class="kpi-card">
+                  <p>Gross margin</p>
+                  <h3>28.4%</h3>
+                </div>
+              </div>
+              <div class="placeholder-img" role="img" aria-label="NeuraTask dashboard with AI Copilot creating a purchase order from chat.">
+                Dashboard mockup placeholder
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="trust-bar" aria-label="Trusted customers">
+          <div class="trust-copy">Trusted by makers, fabricators, and service teams who need to ship on time.</div>
+          <div class="logo-pill">Phoenix Trailers</div>
+          <div class="logo-pill">Acme Fabrication</div>
+          <div class="logo-pill">Northline HVAC</div>
+          <div class="logo-pill">Maple Cabinets</div>
+        </div>
+      </section>
+
+      <section class="section" id="problem-promise">
+        <div class="grid-2">
+          <div>
+            <h2>One platform. Zero silo chaos.</h2>
+          </div>
+          <p class="lead">
+            Spreadsheets, disconnected apps, and paper slow everything down. NeuraTask brings sales, purchasing, inventory, time, and finance into one flow—so your team always knows what’s next.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="copilot">
+        <div class="card">
+          <span class="badge">AI Copilot</span>
+          <h2>Ask. Act. Done.</h2>
+          <p>
+            Type what you need. The Copilot executes: creates records, fills documents, assigns tasks, and updates status—securely and with audit logs.
+          </p>
+          <ul class="list">
+            <li>“Create a quote for ACME with 8× P201 brackets at 20% margin.”</li>
+            <li>“Fill this scanned delivery note and match it to PO #20014.”</li>
+            <li>“Who’s available for a Friday install? Create the task and notify the crew.”</li>
+          </ul>
+          <a class="button button-secondary" href="features.html#copilot">See Copilot in action →</a>
+          <div class="placeholder-img" role="img" aria-label="AI chat commands triggering ERP actions.">
+            Copilot split-screen animation placeholder
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="capabilities">
+        <h2>Key capabilities</h2>
+        <div class="tile-grid">
+          <div class="tile">
+            <h3>Real-time Inventory</h3>
+            <p>Live on-hand, reorder points, audit trail.</p>
+          </div>
+          <div class="tile">
+            <h3>Quote-to-Cash</h3>
+            <p>Quote, order, invoice—margin control at each step.</p>
+          </div>
+          <div class="tile">
+            <h3>Procure-to-Pay</h3>
+            <p>Vendor performance, POs, receipts, bills.</p>
+          </div>
+          <div class="tile">
+            <h3>Time &amp; Attendance</h3>
+            <p>Clock-in/out, projects, labor cost reports.</p>
+          </div>
+          <div class="tile">
+            <h3>Multi-Company</h3>
+            <p>Switch entities with role-based permissions.</p>
+          </div>
+          <div class="tile">
+            <h3>QuickBooks Sync</h3>
+            <p>Customers, invoices, and bills stay aligned.</p>
+          </div>
+        </div>
+        <div class="placeholder-img" role="img" aria-label="Six NeuraTask capability screenshots.">
+          Capability tiles placeholder
+        </div>
+      </section>
+
+      <section class="section" id="outcomes">
+        <h2>Teams ship faster with NeuraTask.</h2>
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <h3>35%</h3>
+            <p>faster quote-to-cash*</p>
+          </div>
+          <div class="metric-card">
+            <h3>3×</h3>
+            <p>faster purchasing cycles*</p>
+          </div>
+          <div class="metric-card">
+            <h3>50%</h3>
+            <p>fewer stockouts*</p>
+          </div>
+          <div class="metric-card">
+            <h3>+1.8pp</h3>
+            <p>margin lift from pricing discipline*</p>
+          </div>
+          <div class="metric-card">
+            <h3>92%</h3>
+            <p>of routine docs auto-filled*</p>
+          </div>
+          <div class="metric-card">
+            <h3>&lt;14 days</h3>
+            <p>to go-live for most SMEs*</p>
+          </div>
+        </div>
+        <p class="lead">*Replace with your validated numbers before publishing.</p>
+      </section>
+
+      <section class="section" id="how-it-works">
+        <h2>How it works</h2>
+        <div class="stepper">
+          <div class="step">
+            <h3>Connect</h3>
+            <p>QuickBooks and import customers, vendors, and products.</p>
+          </div>
+          <div class="step">
+            <h3>Organize</h3>
+            <p>Roles, margins, and workflows.</p>
+          </div>
+          <div class="step">
+            <h3>Run</h3>
+            <p>Operations with the Copilot and task routing.</p>
+          </div>
+        </div>
+        <div class="placeholder-img" role="img" aria-label="Three steps to go live with NeuraTask.">
+          Connect → Organize → Run diagram placeholder
+        </div>
+      </section>
+
+      <section class="section" id="cross-platform">
+        <h2>Wherever your team works.</h2>
+        <p class="lead">
+          Web for operations. Electron desktop for offline work. iOS/Android for time, inventory checks, and approvals. Push notifications keep everyone aligned.
+        </p>
+        <div class="placeholder-img" role="img" aria-label="NeuraTask on web, desktop, and mobile.">
+          Cross-platform device trio placeholder
+        </div>
+      </section>
+
+      <section class="section" id="quotes">
+        <div class="grid-2">
+          <blockquote class="quote">
+            “The Copilot turns a 20-minute PO into two sentences.”
+            <cite>— Ops Lead, Fabrication (placeholder)</cite>
+          </blockquote>
+          <blockquote class="quote">
+            “Time tracking is finally part of the work—not an extra chore.”
+            <cite>— Owner, Services (placeholder)</cite>
+          </blockquote>
+        </div>
+      </section>
+
+      <section class="section" id="final-cta">
+        <div class="final-cta">
+          <h2>Ready to simplify your operations?</h2>
+          <p>Book a demo and see your data in NeuraTask.</p>
+          <div class="button-group">
+            <a class="button button-primary" href="contact.html">Book a demo</a>
+            <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/integrations.html
+++ b/integrations.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Integrations | Connect what you already use</title>
+    <meta
+      name="description"
+      content="Connect NeuraTask with QuickBooks Online today and preview upcoming integrations with accounting, shipping, and e-commerce platforms."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Connect what you already use.</h1>
+            <p class="lead">QuickBooks Online today. More accounting, shipping, and e-commerce integrations coming soon.</p>
+            <a class="button button-primary" href="contact.html">Book a demo</a>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="QuickBooks Online integration card.">
+              QuickBooks integration illustration placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="quickbooks">
+        <div class="card">
+          <h2>QuickBooks Online</h2>
+          <p>Map accounts, sync customers and vendors, export invoices and bills, track export history.</p>
+          <a class="button button-secondary" href="#">Connect QuickBooks →</a>
+        </div>
+      </section>
+
+      <section class="section" id="roadmap">
+        <h2>Roadmap teasers</h2>
+        <p>We’re exploring additional integrations that expand your connected toolkit.</p>
+        <div class="integration-roadmap">
+          <span>Xero</span>
+          <span>Sage</span>
+          <span>Shopify</span>
+          <span>ShipStation</span>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Pricing | Simple pricing that scales</title>
+    <meta
+      name="description"
+      content="Choose the right NeuraTask plan. All tiers include AI Copilot, inventory, sales, purchasing, and QuickBooks sync with options for enterprise controls."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Simple pricing that scales with your team.</h1>
+            <p class="lead">All plans include the AI Copilot, inventory, sales, purchasing, and QuickBooks sync.</p>
+            <div class="button-group">
+              <a class="button button-primary" href="contact.html">Contact sales</a>
+              <a class="button button-secondary" href="#plans">View plans</a>
+            </div>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Pricing plan comparison.">
+              Pricing tiers illustration placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="plans">
+        <h2>Plans</h2>
+        <table class="table">
+          <caption>Choose the right plan for your SME.</caption>
+          <thead>
+            <tr>
+              <th scope="col">Plan</th>
+              <th scope="col">Price</th>
+              <th scope="col">Highlights</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Starter</th>
+              <td>$29/user/mo</td>
+              <td>Up to 10 users, core modules, QBO sync, 5 GB storage.</td>
+            </tr>
+            <tr>
+              <th scope="row">Growth</th>
+              <td>$59/user/mo</td>
+              <td>Unlimited users, advanced inventory, Doc AI (500 pages/mo), priority support.</td>
+            </tr>
+            <tr>
+              <th scope="row">Enterprise</th>
+              <td>Custom</td>
+              <td>Multi-company, SSO, advanced audit, dedicated success, premium SLAs.</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="button-group" style="margin-top: 2rem;">
+          <a class="button button-primary" href="pricing.html">Start free trial</a>
+          <a class="button button-secondary" href="contact.html">Contact sales</a>
+        </div>
+      </section>
+
+      <section class="section" id="faq">
+        <h2>Pricing FAQ</h2>
+        <div class="faq">
+          <div class="faq-item">
+            <h3>How am I billed?</h3>
+            <p>Choose monthly or annual billing. Upgrade or add users anytime.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Do you help with onboarding?</h3>
+            <p>Yes—guided setup plus playbooks for roles, inventory, and financial workflows.</p>
+          </div>
+          <div class="faq-item">
+            <h3>Can I export my data?</h3>
+            <p>Anytime. Export customers, products, transactions, and audit logs in CSV or PDF.</p>
+          </div>
+          <div class="faq-item">
+            <h3>What about security?</h3>
+            <p>Role-based permissions, TLS encryption, audit trails, and device controls keep data safe.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="cta">
+        <div class="final-cta">
+          <h2>Ready to get started?</h2>
+          <p>Launch your 14-day free trial or schedule time with our team.</p>
+          <div class="button-group">
+            <a class="button button-primary" href="pricing.html">Start free trial</a>
+            <a class="button button-secondary" href="contact.html">Book a demo</a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/product.html
+++ b/product.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Product | Your operations in one place</title>
+    <meta
+      name="description"
+      content="Explore NeuraTask modules spanning customers, vendors, products, inventory, sales, purchasing, time, employees, and finance in one AI-powered ERP."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Your operations in one place.</h1>
+            <p class="lead">
+              NeuraTask centralizes customers, vendors, products, inventory, sales, purchasing, time, employees, and finance.
+            </p>
+            <div class="button-group">
+              <a class="button button-primary" href="contact.html">Book a demo</a>
+              <a class="button button-secondary" href="pricing.html">Start free trial</a>
+            </div>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Annotated NeuraTask product modules.">
+              Product modules overview placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="modules">
+        <h2>Modules</h2>
+        <div class="card">
+          <ul class="list">
+            <li><strong>Authentication &amp; Users:</strong> Secure JWT login, role-aware access, multi-company sessions, encrypted passwords, and session persistence.</li>
+            <li><strong>Business Profile:</strong> Company info, branding, GST/tax, defaults.</li>
+            <li><strong>Customers:</strong> Records, contacts, addresses, history, analytics; sync to QuickBooks.</li>
+            <li><strong>Vendors:</strong> Profiles, performance, contacts; sync to QuickBooks.</li>
+            <li><strong>Products:</strong> Catalogs, categories, pricing, specs, PDF export, deletion controls.</li>
+            <li><strong>Inventory:</strong> Stock vs supply items, real-time quantities, reorders, cost/margin, audit logs, multiple create paths.</li>
+            <li><strong>Sales:</strong> Quotes→Orders, line items, margins, status, PDFs, history, QuickBooks export, parts-to-order pipeline.</li>
+            <li><strong>Purchasing:</strong> POs, vendor assignment, status, PDFs, QuickBooks export, spend analysis.</li>
+            <li><strong>Margin &amp; Pricing:</strong> Margin schedules, labor/overhead rates, automated price calc, profitability monitor.</li>
+            <li><strong>Time &amp; Attendance:</strong> Attendance, project time, timesheets, reports, labor cost, shifts.</li>
+            <li><strong>Employees:</strong> Roles/permissions, records, contact info, history, performance.</li>
+            <li><strong>Parts to Order:</strong> Aggregated needs across orders, auto-quantities, vendor assignment, cost tracking.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="experience">
+        <h2>Application experience layers</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Frontend</h3>
+            <p>Responsive layout, auth-aware UI, embedded chat, modular dialogs, validated forms, dashboards with role-based menus.</p>
+          </div>
+          <div class="card">
+            <h3>Backend</h3>
+            <p>Auth, database, files, email, PDF generation, uploads, notifications, pooling, transactions, error handling.</p>
+          </div>
+        </div>
+        <div class="placeholder-img" role="img" aria-label="NeuraTask architecture overview.">
+          Architecture diagram placeholder
+        </div>
+      </section>
+
+      <section class="section" id="outcomes">
+        <h2>Outcomes &amp; proof</h2>
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <h3>99.95%</h3>
+            <p>Uptime SLA target*</p>
+          </div>
+          <div class="metric-card">
+            <h3>&lt;200 ms</h3>
+            <p>Median API response*</p>
+          </div>
+          <div class="metric-card">
+            <h3>7–14 days</h3>
+            <p>Typical implementation*</p>
+          </div>
+          <div class="metric-card">
+            <h3>90 minutes</h3>
+            <p>Average training time per role*</p>
+          </div>
+        </div>
+        <p class="lead">*Replace with measured metrics.</p>
+        <a class="button button-primary" href="contact.html">Book a demo</a>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Resources | Guides, blogs, and templates</title>
+    <meta
+      name="description"
+      content="Browse NeuraTask resources including blog topics, guides, templates, and case study stories for SMEs."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Resources for your SME team.</h1>
+            <p class="lead">Playbooks, templates, and case studies to run operations with confidence.</p>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Resource hub layout.">
+              Resource hub illustration placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="blog">
+        <h2>Blog topics</h2>
+        <ul class="list">
+          <li>“From quotes to cash: a playbook for SMEs”</li>
+          <li>“How AI form-filling actually reduces errors”</li>
+          <li>“Parts-to-order: the secret to fewer stockouts”</li>
+          <li>“Choosing reorder points without the guesswork”</li>
+        </ul>
+      </section>
+
+      <section class="section" id="guides">
+        <h2>Guides &amp; templates</h2>
+        <ul class="list">
+          <li>Quote template (PDF)</li>
+          <li>PO checklist</li>
+          <li>Inventory cycle count sheet</li>
+          <li>Time tracking policy template</li>
+        </ul>
+      </section>
+
+      <section class="section" id="case-studies">
+        <div class="card">
+          <h2>Phoenix Trailers cuts stockouts by <span class="highlight">50%</span> with NeuraTask*</h2>
+          <p>With AI Copilot and parts-to-order, purchasing cycles sped up <strong>3×</strong> and on-time deliveries improved.*</p>
+          <a class="button button-secondary" href="#">Read the story →</a>
+          <p class="lead">*Replace with verified figures.</p>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/security.html
+++ b/security.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Security | Security by design</title>
+    <meta
+      name="description"
+      content="Learn how NeuraTask protects your data with role-based access, encryption, audit logs, backups, and device controls."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Security by design.</h1>
+            <p class="lead">Stay compliant and confident with layered protection across people, process, and platform.</p>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Role-based access and audit trails.">
+              Security diagram placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="principles">
+        <h2>How NeuraTask protects your data</h2>
+        <ul class="list">
+          <li>Role-based access and least privilege</li>
+          <li>Encrypted passwords, TLS in transit</li>
+          <li>Audit logs for user and Copilot actions</li>
+          <li>Backups and disaster recovery</li>
+          <li>Data residency options (on request)</li>
+          <li>Mobile device session controls</li>
+        </ul>
+      </section>
+
+      <section class="section" id="cta">
+        <div class="final-cta">
+          <h2>Need more detail?</h2>
+          <p>Request our security briefing and share your compliance checklist.</p>
+          <div class="button-group">
+            <a class="button button-primary" href="contact.html">Book a demo</a>
+            <a class="button button-secondary" href="contact.html">Contact security team</a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/solutions.html
+++ b/solutions.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NeuraTask Solutions | Built for makers and service teams</title>
+    <meta
+      name="description"
+      content="See how NeuraTask empowers fabrication, cabinetry, HVAC, services, and light manufacturing teams with AI-powered ERP workflows."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" aria-label="Main navigation">
+        <a class="nav-logo" href="./">NeuraTask</a>
+        <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
+          <span aria-hidden="true">☰</span>
+        </button>
+        <ul class="nav-links">
+          <li><a href="product.html">Product</a></li>
+          <li><a href="features.html">Features</a></li>
+          <li><a href="solutions.html">Solutions</a></li>
+          <li><a href="pricing.html">Pricing</a></li>
+          <li><a href="resources.html">Resources</a></li>
+          <li><a href="integrations.html">Integrations</a></li>
+          <li><a href="security.html">Security</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="contact.html">Book a demo</a></li>
+        </ul>
+        <div class="nav-actions">
+          <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          <a class="button button-primary" href="contact.html">Book a demo</a>
+        </div>
+      </nav>
+    </header>
+    <main>
+      <section class="section hero">
+        <div class="hero-grid">
+          <div class="hero-content">
+            <h1>Built for makers and service teams.</h1>
+            <p class="lead">Tailored workflows for fabrication, cabinetry, HVAC, services, and light manufacturing.</p>
+            <a class="button button-primary" href="contact.html">See a demo for your industry</a>
+          </div>
+          <div class="hero-image">
+            <div class="placeholder-img" role="img" aria-label="Industry workflows with NeuraTask overlays.">
+              Industry overlays placeholder
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="fabrication">
+        <div class="card">
+          <h2>Fabrication</h2>
+          <ul class="list">
+            <li>Quote assemblies fast.</li>
+            <li>Auto-generate PO bundles.</li>
+            <li>Margin guardrails.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="cabinetry">
+        <div class="card">
+          <h2>Cabinetry &amp; Wood</h2>
+          <ul class="list">
+            <li>Track finish materials.</li>
+            <li>Batch POs.</li>
+            <li>Install scheduling.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="hvac">
+        <div class="card">
+          <h2>HVAC &amp; Services</h2>
+          <ul class="list">
+            <li>Mobile clock-ins.</li>
+            <li>On-site parts.</li>
+            <li>Customer approvals.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="manufacturing">
+        <div class="card">
+          <h2>Light Manufacturing</h2>
+          <ul class="list">
+            <li>BOM-like kits.</li>
+            <li>Reorder points.</li>
+            <li>Supplier scorecards.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section" id="cta">
+        <div class="final-cta">
+          <h2>See NeuraTask in your workflow.</h2>
+          <p>Book a tailored demo for your team and industry.</p>
+          <div class="button-group">
+            <a class="button button-primary" href="contact.html">Book a demo</a>
+            <a class="button button-secondary" href="pricing.html">Start free trial</a>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="footer-inner">
+        <div class="tagline">
+          <div class="nav-logo">NeuraTask</div>
+          <p>Run your SME on one AI-powered platform. Ask. Act. Done.</p>
+          <div class="badge-grid">
+            <span>QuickBooks</span>
+            <span>iOS</span>
+            <span>Android</span>
+            <span>Windows</span>
+            <span>macOS</span>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div class="footer-col">
+            <h4>Product</h4>
+            <ul>
+              <li><a href="product.html">Overview</a></li>
+              <li><a href="features.html">AI Copilot</a></li>
+              <li><a href="integrations.html">Integrations</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Solutions</h4>
+            <ul>
+              <li><a href="solutions.html#fabrication">Fabrication</a></li>
+              <li><a href="solutions.html#cabinetry">Cabinetry &amp; Wood</a></li>
+              <li><a href="solutions.html#hvac">HVAC &amp; Services</a></li>
+              <li><a href="solutions.html#manufacturing">Light Manufacturing</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Resources</h4>
+            <ul>
+              <li><a href="resources.html#blog">Blog</a></li>
+              <li><a href="resources.html#guides">Guides &amp; templates</a></li>
+              <li><a href="resources.html#case-studies">Case studies</a></li>
+              <li><a href="pricing.html#faq">Pricing FAQ</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Company</h4>
+            <ul>
+              <li><a href="about.html">About</a></li>
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="security.html">Security</a></li>
+            </ul>
+          </div>
+          <div class="footer-col">
+            <h4>Legal</h4>
+            <ul>
+              <li><a href="#">Privacy policy</a></li>
+              <li><a href="#">Terms of service</a></li>
+              <li><a href="#">Cookie policy</a></li>
+            </ul>
+          </div>
+        </div>
+        <div class="newsletter">
+          <h4>Subscribe for product updates</h4>
+          <p>Tips, releases, and customer stories—no spam.</p>
+          <form>
+            <label class="sr-only" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" name="email" placeholder="you@company.com" required />
+            <button class="button button-primary" type="submit">Subscribe</button>
+          </form>
+          <div class="social-links" aria-label="Social media">
+            <a href="#">LinkedIn</a>
+            <a href="#">X</a>
+            <a href="#">YouTube</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a multi-page static marketing site for NeuraTask with hero messaging, trust signals, capability overviews, outcomes, and CTAs
- add dedicated pages for product modules, feature deep dives, industry solutions, integrations, pricing, security, resources, about, and contact copy
- introduce shared styling and lightweight navigation scripting to deliver a cohesive responsive experience
- refresh the design tokens and component styling to deliver a bright, light-themed presentation aligned with user feedback

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e559d5ccf48324a723e8cfb9d65cb7